### PR TITLE
Simulate ofdm mimo channel estimation

### DIFF
--- a/channel_estimation_ofdm_mimo.m
+++ b/channel_estimation_ofdm_mimo.m
@@ -209,33 +209,20 @@ function [ofdm_tx, pilot_positions, data_positions] = create_ofdm_signal(tx_symb
     n_data_per_symbol = length(data_positions);
     tx_symbols_reshaped = reshape(tx_symbols, n_data_per_symbol, params.N_tx, []);
     
-%<<<<<<< cursor/simulate-ofdm-mimo-channel-estimation-90b2
     % Initialize OFDM signal (frequency domain first)
     ofdm_freq = zeros(params.N_subcarriers, params.N_tx, params.N_symbols);
-=======
-    % Initialize OFDM signal
-    ofdm_tx = zeros(params.N_subcarriers, params.N_tx, params.N_symbols);
-%>>>>>>> main
     
     for sym_idx = 1:params.N_symbols
         for tx_idx = 1:params.N_tx
             % Insert pilots
-%<<<<<<< cursor/simulate-ofdm-mimo-channel-estimation-90b2
             ofdm_freq(pilot_positions, tx_idx, sym_idx) = pilot_symbols;
             % Insert data
             if sym_idx <= size(tx_symbols_reshaped, 3)
                 ofdm_freq(data_positions, tx_idx, sym_idx) = tx_symbols_reshaped(:, tx_idx, sym_idx);
-=======
-            ofdm_tx(pilot_positions, tx_idx, sym_idx) = pilot_symbols;
-            % Insert data
-            if sym_idx <= size(tx_symbols_reshaped, 3)
-                ofdm_tx(data_positions, tx_idx, sym_idx) = tx_symbols_reshaped(:, tx_idx, sym_idx);
-%>>>>>>> main
             end
         end
     end
     
-%<<<<<<< cursor/simulate-ofdm-mimo-channel-estimation-90b2
     % Initialize time domain OFDM signal with cyclic prefix
     ofdm_tx = zeros(params.N_subcarriers + params.N_cp, params.N_tx, params.N_symbols);
     
@@ -243,12 +230,6 @@ function [ofdm_tx, pilot_positions, data_positions] = create_ofdm_signal(tx_symb
     for sym_idx = 1:params.N_symbols
         for tx_idx = 1:params.N_tx
             ifft_out = ifft(ofdm_freq(:, tx_idx, sym_idx), params.N_subcarriers);
-=======
-    % Apply IFFT and add cyclic prefix
-    for sym_idx = 1:params.N_symbols
-        for tx_idx = 1:params.N_tx
-            ifft_out = ifft(ofdm_tx(:, tx_idx, sym_idx), params.N_subcarriers);
-%>>>>>>> main
             % Add cyclic prefix
             ofdm_tx(:, tx_idx, sym_idx) = [ifft_out(end-params.N_cp+1:end); ifft_out];
         end

--- a/run_clean.m
+++ b/run_clean.m
@@ -1,0 +1,44 @@
+%% Clean Run Script - Channel Estimation OFDM MIMO
+% This script clears all cached functions and variables before running
+
+% Clear everything
+clear all;
+close all;
+clc;
+
+% Clear function cache
+clear functions;
+
+% Display current directory
+fprintf('Current directory: %s\n', pwd);
+
+% List MATLAB files to confirm we have the right files
+fprintf('\nMATLAB files in current directory:\n');
+files = dir('*.m');
+for i = 1:length(files)
+    fprintf('  %s\n', files(i).name);
+end
+
+% Run the main simulation
+fprintf('\n=== Starting Clean Simulation ===\n');
+try
+    channel_estimation_ofdm_mimo;
+    fprintf('\n=== Simulation Completed Successfully! ===\n');
+catch ME
+    fprintf('\n=== Error Occurred ===\n');
+    fprintf('Error: %s\n', ME.message);
+    fprintf('File: %s\n', ME.stack(1).file);
+    fprintf('Line: %d\n', ME.stack(1).line);
+    
+    % Display the problematic line if possible
+    if exist(ME.stack(1).file, 'file')
+        try
+            lines = readlines(ME.stack(1).file);
+            if length(lines) >= ME.stack(1).line
+                fprintf('Problematic line: %s\n', lines(ME.stack(1).line));
+            end
+        catch
+            % Ignore if can't read file
+        end
+    end
+end


### PR DESCRIPTION
Fixes multiple MATLAB runtime errors by correcting OFDM signal sizing, restructuring the main script, and replacing the `comm.MIMOChannel` with a custom implementation.

This PR resolves several critical issues:
1.  **OFDM Signal Sizing:** The `create_ofdm_signal` function previously attempted to assign a cyclic-prefix-padded signal (80 elements) to an array sized for only subcarriers (64 elements), causing a dimension mismatch error. This is fixed by correctly sizing the time-domain OFDM array.
2.  **Script/Function Structure:** MATLAB's requirement for script code to precede all function definitions in a single file was violated, leading to "Function definition is misplaced" errors. The main script is now correctly structured.
3.  **MIMO Channel Simulation:** The `comm.MIMOChannel` object caused "Too many output arguments" errors and configuration warnings. It has been replaced with a custom multipath MIMO channel implementation that provides the expected outputs and avoids toolbox-specific issues.
A `run_clean.m` script is also added to ensure a fresh MATLAB environment for execution, preventing caching-related problems.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-81b17f8c-0193-4fdf-8b58-8b47f15ea7fa) · [Cursor](https://cursor.com/background-agent?bcId=bc-81b17f8c-0193-4fdf-8b58-8b47f15ea7fa)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)